### PR TITLE
273 - Updated Item association

### DIFF
--- a/apilayer/handler/CategoriesHandler.go
+++ b/apilayer/handler/CategoriesHandler.go
@@ -273,6 +273,45 @@ func AddItemsInCategory(rw http.ResponseWriter, r *http.Request, user string) {
 	json.NewEncoder(rw).Encode(resp)
 }
 
+// RemoveAssociationFromCategory ...
+// swagger:route POST /api/v1/category/remove/items Categories RemoveAssociationFromCategory
+//
+// # Removes association between the category and asset item
+//
+// Parameters:
+//   - +name: CategoryItemRequest
+//     in: body
+//     description: The object containing the array of assets to update with the userID
+//     type: CategoryItemRequest
+//     required: true
+//
+// Responses:
+// 200: MessageResponse
+// 400: MessageResponse
+// 404: MessageResponse
+// 500: MessageResponse
+func RemoveAssociationFromCategory(rw http.ResponseWriter, r *http.Request, user string) {
+
+	draftCategoryItemRequest := &model.CategoryItemRequest{}
+	err := json.NewDecoder(r.Body).Decode(draftCategoryItemRequest)
+	r.Body.Close()
+	if err != nil {
+		log.Printf("Unable to decode request parameters. error: +%v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(err)
+		return
+	}
+	err = db.RemoveAssetAssociationFromCategory(user, draftCategoryItemRequest)
+	if err != nil {
+		log.Printf("Unable to remove assets from selected category. error: +%v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(err)
+		return
+	}
+	rw.Header().Add("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusOK)
+}
+
 // UpdateCategory ...
 // swagger:route PUT /api/v1/category/{id} Categories updateCategory
 //

--- a/apilayer/handler/CategoriesHandler.go
+++ b/apilayer/handler/CategoriesHandler.go
@@ -241,7 +241,7 @@ func CreateCategory(rw http.ResponseWriter, r *http.Request, user string) {
 // Parameters:
 //   - +name: CategoryItemRequest
 //     in: body
-//     description: The object containing the array of assets to update with the userID
+//     description: The object containing the array of assets to be removed from the association for categories
 //     type: CategoryItemRequest
 //     required: true
 //

--- a/apilayer/handler/MaintenancePlan.go
+++ b/apilayer/handler/MaintenancePlan.go
@@ -224,6 +224,45 @@ func AddItemsInMaintenancePlan(rw http.ResponseWriter, r *http.Request, user str
 	json.NewEncoder(rw).Encode(resp)
 }
 
+// RemoveAssociationFromMaintenancePlan ...
+// swagger:route POST /api/v1/plan/remove/items MaintenancePlans RemoveAssociationFromMaintenancePlan
+//
+// # Removes association between the maintenance plan and asset item
+//
+// Parameters:
+//   - +name: MaintenanceItemRequest
+//     in: body
+//     description: The object containing the array of assets to be removed
+//     type: MaintenanceItemRequest
+//     required: true
+//
+// Responses:
+// 200: MessageResponse
+// 400: MessageResponse
+// 404: MessageResponse
+// 500: MessageResponse
+func RemoveAssociationFromMaintenancePlan(rw http.ResponseWriter, r *http.Request, user string) {
+
+	draftMaintenancePlanItemRequest := &model.MaintenanceItemRequest{}
+	err := json.NewDecoder(r.Body).Decode(draftMaintenancePlanItemRequest)
+	r.Body.Close()
+	if err != nil {
+		log.Printf("Unable to decode request parameters. error: +%v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(err)
+		return
+	}
+	err = db.RemoveAssetAssociationFromMaintenancePlan(user, draftMaintenancePlanItemRequest)
+	if err != nil {
+		log.Printf("Unable to remove assets from selected maintenance plan. error: +%v", err)
+		rw.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(rw).Encode(err)
+		return
+	}
+	rw.Header().Add("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusOK)
+}
+
 // CreateMaintenancePlan ...
 // swagger:route POST /api/v1/plan MaintenancePlans createMaintenancePlan
 //

--- a/apilayer/handler/MaintenancePlan.go
+++ b/apilayer/handler/MaintenancePlan.go
@@ -192,7 +192,7 @@ func GetAllMaintenancePlanItems(rw http.ResponseWriter, r *http.Request, user st
 // Parameters:
 //   - +name: MaintenanceItemRequest
 //     in: body
-//     description: The object containing the array of assets to update with the userID
+//     description:The object containing the array of assets to be removed from the association for maintenance plans
 //     type: MaintenanceItemRequest
 //     required: true
 //

--- a/apilayer/handler/MaintenancePlan_test.go
+++ b/apilayer/handler/MaintenancePlan_test.go
@@ -639,3 +639,181 @@ func Test_AddItemsInMaintenancePlan_InvalidDBUser(t *testing.T) {
 	assert.Equal(t, 400, res.StatusCode)
 	assert.Equal(t, "400 Bad Request", res.Status)
 }
+
+func Test_RemoveAssociationFromMaintenancePlan(t *testing.T) {
+
+	// retrieve the selected profile
+	draftUserCredentials := model.UserCredentials{
+		Email:             "admin@gmail.com",
+		Role:              "TESTER",
+		EncryptedPassword: "1231231",
+	}
+
+	db.PreloadAllTestVariables()
+	prevUser, err := db.RetrieveUser(config.CTO_USER, &draftUserCredentials)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	draftMaintenancePlan := model.MaintenancePlan{
+		Name:           "Kitty litter box",
+		Description:    "Palette storage of kitty litter",
+		Color:          "#f7f7f7",
+		Status:         "completed",
+		MaxItemsLimit:  120,
+		MinItemsLimit:  1,
+		PlanType:       "annual",
+		PlanDue:        time.Now().AddDate(1, 0, 0),
+		CreatedBy:      prevUser.ID.String(),
+		UpdatedBy:      prevUser.ID.String(),
+		SharableGroups: []string{prevUser.ID.String()},
+	}
+
+	// Marshal the draftEvent into JSON bytes
+	requestBody, err := json.Marshal(draftMaintenancePlan)
+	if err != nil {
+		t.Errorf("failed to marshal JSON: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/plan", bytes.NewBuffer(requestBody))
+	w := httptest.NewRecorder()
+	CreateMaintenancePlan(w, req, config.CTO_USER)
+	res := w.Result()
+	defer res.Body.Close()
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+	assert.Equal(t, 200, res.StatusCode)
+
+	var selectedMaintenancePlan model.MaintenancePlan
+	err = json.Unmarshal(data, &selectedMaintenancePlan)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	assert.Equal(t, selectedMaintenancePlan.Name, "Kitty litter box")
+	assert.Equal(t, selectedMaintenancePlan.Description, "Palette storage of kitty litter")
+	assert.Equal(t, selectedMaintenancePlan.StatusName, "completed")
+	assert.Equal(t, selectedMaintenancePlan.MaxItemsLimit, 120)
+	assert.Equal(t, selectedMaintenancePlan.MinItemsLimit, 1)
+	assert.Equal(t, selectedMaintenancePlan.PlanType, "annual")
+	assert.Equal(t, len(selectedMaintenancePlan.SharableGroups), 1)
+	assert.Equal(t, selectedMaintenancePlan.SharableGroups[0], prevUser.ID.String())
+
+	// retrieve inventory list
+	req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/profile/%s/inventories", prevUser.ID), nil)
+	req = mux.SetURLVars(req, map[string]string{"id": prevUser.ID.String()})
+	w = httptest.NewRecorder()
+	GetAllInventories(w, req, config.CTO_USER)
+	res = w.Result()
+	defer res.Body.Close()
+	data, err = io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Greater(t, len(data), 0)
+
+	var inventories []model.Inventory
+	err = json.Unmarshal(data, &inventories)
+	if err != nil {
+		t.Errorf("expected error to be nil but got %+v", err)
+	}
+
+	selectedInventory := inventories[0]
+
+	draftAssets := model.MaintenanceItemRequest{
+		ID:            selectedMaintenancePlan.ID,
+		UserID:        prevUser.ID.String(),
+		AssetIDs:      []string{selectedInventory.ID},
+		Collaborators: []string{prevUser.ID.String(), prevUser.ID.String()},
+	}
+
+	// Marshal the draftEvent into JSON bytes
+	requestBody, err = json.Marshal(draftAssets)
+	if err != nil {
+		t.Errorf("failed to marshal JSON: %v", err)
+	}
+
+	// retrieve inventory list
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/plans/items", bytes.NewBuffer(requestBody))
+	w = httptest.NewRecorder()
+	AddItemsInMaintenancePlan(w, req, config.CTO_USER)
+	res = w.Result()
+	defer res.Body.Close()
+	data, err = io.ReadAll(res.Body)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Greater(t, len(data), 0)
+
+	var maintenanceItemResponse []model.MaintenanceItemResponse
+	err = json.Unmarshal(data, &maintenanceItemResponse)
+	if err != nil {
+		t.Errorf("expected error to be nil got %v", err)
+	}
+
+	assert.Equal(t, maintenanceItemResponse[0].MaintenancePlanID, selectedMaintenancePlan.ID)
+	assert.Equal(t, maintenanceItemResponse[0].ItemID, selectedInventory.ID)
+	assert.Equal(t, len(maintenanceItemResponse[0].SharableGroups), 2)
+	assert.Equal(t, maintenanceItemResponse[0].SharableGroups[0], prevUser.ID.String())
+	assert.Equal(t, maintenanceItemResponse[0].SharableGroups[1], prevUser.ID.String())
+
+	// Remove items from category
+
+	draftAssetToRemove := model.MaintenanceItemRequest{
+		ID:            selectedMaintenancePlan.ID,
+		UserID:        prevUser.ID.String(),
+		AssetIDs:      []string{selectedInventory.ID},
+		Collaborators: []string{prevUser.ID.String(), prevUser.ID.String()},
+	}
+
+	// Marshal the draftEvent into JSON bytes
+	requestBody, err = json.Marshal(draftAssetToRemove)
+	if err != nil {
+		t.Errorf("failed to marshal JSON: %v", err)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/plan/remove/items", bytes.NewBuffer(requestBody))
+	w = httptest.NewRecorder()
+	RemoveAssociationFromCategory(w, req, config.CTO_USER)
+	res = w.Result()
+	defer res.Body.Close()
+
+	assert.Equal(t, 200, res.StatusCode)
+
+	// cleanup
+	db.RemoveMaintenancePlan(config.CTO_USER, maintenanceItemResponse[0].MaintenancePlanID)
+}
+
+func Test_RemoveAssociationFromMaintenancePlan_IncorrectUserID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/plan/remove/items", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "request"})
+	w := httptest.NewRecorder()
+	db.PreloadAllTestVariables()
+	RemoveAssociationFromMaintenancePlan(w, req, config.CTO_USER)
+	res := w.Result()
+
+	assert.Equal(t, 400, res.StatusCode)
+	assert.Equal(t, "400 Bad Request", res.Status)
+}
+
+func Test_RemoveAssociationFromMaintenancePlan_InvalidDBUser(t *testing.T) {
+
+	draftMaintenanceItemRequest := model.MaintenanceItemRequest{}
+	requestBody, err := json.Marshal(draftMaintenanceItemRequest)
+	if err != nil {
+		t.Errorf("failed to marshal JSON: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/plan/remove/items", bytes.NewBuffer(requestBody))
+	w := httptest.NewRecorder()
+	RemoveAssociationFromMaintenancePlan(w, req, config.CEO_USER)
+	res := w.Result()
+
+	assert.Equal(t, 400, res.StatusCode)
+	assert.Equal(t, "400 Bad Request", res.Status)
+}

--- a/apilayer/main.go
+++ b/apilayer/main.go
@@ -75,6 +75,8 @@ func main() {
 	// categories
 	router.Handle("/api/v1/category/items", CustomRequestHandler(handler.GetAllCategoryItems)).Methods(http.MethodGet)
 	router.Handle("/api/v1/category/items", CustomRequestHandler(handler.AddItemsInCategory)).Methods(http.MethodPost)
+	router.Handle("/api/v1/category/remove/items", CustomRequestHandler(handler.RemoveAssociationFromCategory)).Methods(http.MethodPost)
+
 	router.Handle("/api/v1/categories", CustomRequestHandler(handler.GetAllCategories)).Methods(http.MethodGet)
 	router.Handle("/api/v1/category", CustomRequestHandler(handler.GetCategory)).Methods(http.MethodGet)
 	router.Handle("/api/v1/category", CustomRequestHandler(handler.CreateCategory)).Methods(http.MethodPost)
@@ -84,6 +86,8 @@ func main() {
 	// maintenance plans
 	router.Handle("/api/v1/plans/items", CustomRequestHandler(handler.GetAllMaintenancePlanItems)).Methods(http.MethodGet)
 	router.Handle("/api/v1/plans/items", CustomRequestHandler(handler.AddItemsInMaintenancePlan)).Methods(http.MethodPost)
+	router.Handle("/api/v1/plan/remove/items", CustomRequestHandler(handler.RemoveAssociationFromMaintenancePlan)).Methods(http.MethodPost)
+
 	router.Handle("/api/v1/maintenance-plans", CustomRequestHandler(handler.GetAllMaintenancePlans)).Methods(http.MethodGet)
 	router.Handle("/api/v1/plan", CustomRequestHandler(handler.CreateMaintenancePlan)).Methods(http.MethodPost)
 	router.Handle("/api/v1/plan", CustomRequestHandler(handler.GetMaintenancePlan)).Methods(http.MethodGet)

--- a/apilayer/model/Inventory.go
+++ b/apilayer/model/Inventory.go
@@ -33,7 +33,7 @@ type Inventory struct {
 	CreatorName        string     `json:"creator_name"`
 	UpdatedAt          time.Time  `json:"updated_at"`
 	UpdatedBy          string     `json:"updated_by"`
-	UpdaterName        string     `json:"updater_name"`
+	UpdaterName        string     `json:"updator"`
 	BoughtAt           string     `json:"bought_at"`
 	SharableGroups     []string   `json:"sharable_groups"`
 }

--- a/frontend/src/common/RowHeader.jsx
+++ b/frontend/src/common/RowHeader.jsx
@@ -11,6 +11,7 @@ const RowHeader = ({
   primaryStartIcon,
   secondaryButtonTextLabel,
   secondaryStartIcon,
+  secondaryButtonDisabled,
   handleClickPrimaryButton,
   handleClickSecondaryButton,
   children,
@@ -49,6 +50,7 @@ const RowHeader = ({
             size="small"
             color="primary"
             variant="outlined"
+            disabled={secondaryButtonDisabled}
             onClick={handleClickSecondaryButton}
             startIcon={secondaryStartIcon}
           >

--- a/frontend/src/common/SimpleModal.jsx
+++ b/frontend/src/common/SimpleModal.jsx
@@ -1,8 +1,18 @@
-import { Button, Dialog, DialogContent, DialogTitle, IconButton, Stack, Typography } from '@mui/material';
-import { CloseRounded, DownloadRounded } from '@mui/icons-material';
+import { CloseRounded } from '@mui/icons-material';
+import { Dialog, DialogContent, DialogTitle, IconButton, Stack, Typography } from '@mui/material';
 
 const SimpleModal = (props) => {
-  const { title, subtitle, handleClose, maxSize, showExport = false, handleExport = () => {}, children } = props;
+  const {
+    title,
+    subtitle,
+    handleClose,
+    maxSize,
+    showSecondaryButton = false,
+    disableSecondaryButton,
+    secondaryButtonAction,
+    secondaryButtonIcon,
+    children,
+  } = props;
 
   return (
     <Dialog open={true} onClose={handleClose} maxWidth={maxSize ?? 'xl'} fullWidth>
@@ -13,10 +23,10 @@ const SimpleModal = (props) => {
             {subtitle ? <Typography variant="caption">{subtitle}</Typography> : null}
           </Stack>
           <Stack direction="row" alignItems="center">
-            {showExport && (
-              <Button endIcon={<DownloadRounded />} onClick={handleExport}>
-                Export
-              </Button>
+            {showSecondaryButton && (
+              <IconButton color="primary" onClick={secondaryButtonAction} disabled={disableSecondaryButton}>
+                {secondaryButtonIcon}
+              </IconButton>
             )}
             <IconButton aria-label="close" onClick={handleClose} color="error">
               <CloseRounded />

--- a/frontend/src/common/utils.jsx
+++ b/frontend/src/common/utils.jsx
@@ -44,7 +44,7 @@ export const ConfirmationBoxModal = ({ openDialog, title, handleClose, maxSize, 
       <Typography variant="subtitle2">Delete this item?</Typography>
       <Stack direction="row" justifyContent="flex-end" spacing={1}>
         <Button onClick={handleClose}>Go back</Button>
-        <Button variant="outlined" autoFocus onClick={() => confirmDelete(deleteID)}>
+        <Button variant="outlined" autoFocus onClick={() => confirmDelete(deleteID || true)}>
           Confirm
         </Button>
       </Stack>

--- a/frontend/src/features/Categories/constants.jsx
+++ b/frontend/src/features/Categories/constants.jsx
@@ -1,12 +1,3 @@
-export const ITEMS_IN_CATEGORY_HEADER = [
-  { field: 'name', headerName: 'Name', flex: 1 },
-  { field: 'description', headerName: 'Description', flex: 2 },
-  { field: 'price', headerName: 'Price', flex: 1 },
-  { field: 'quantity', headerName: 'Quantity', flex: 1 },
-  { field: 'location', headerName: 'Storage Location', flex: 1 },
-  { field: 'updator', headerName: 'Last updated by', flex: 1 },
-];
-
 const GENERIC_FORM_FIELDS = {
   type: 'text',
   variant: 'outlined',

--- a/frontend/src/features/CategoryItemDetails/CategoryItemDetails.jsx
+++ b/frontend/src/features/CategoryItemDetails/CategoryItemDetails.jsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Skeleton, Stack } from '@mui/material';
+import { AddRounded } from '@mui/icons-material';
 
 import SimpleModal from '../../common/SimpleModal';
 import { inventoryActions } from '../InventoryList/inventorySlice';
@@ -37,6 +38,16 @@ export default function CategoryItemDetails() {
     setRowSelected([]);
   };
 
+  const addItems = () => {
+    const collaborators = selectedCategory.sharable_groups;
+    dispatch(categoryItemDetailsActions.addItemsInCategory({ id: selectedCategory?.id, rowSelected, collaborators }));
+    resetSelection();
+  };
+
+  const handleRemoveAssociation = () => {
+    dispatch(categoryItemDetailsActions.removeItemsFromCategory({ id: selectedCategory?.id, rowSelected }));
+  };
+
   useEffect(() => {
     if (id) {
       dispatch(categoryItemDetailsActions.getItemsForCategory(id));
@@ -57,16 +68,28 @@ export default function CategoryItemDetails() {
         itemsInCategory={itemsInCategory}
         handleOpenModal={handleOpenModal}
       />
-      <CategoryItemDetailsDataTable itemsInCategory={itemsInCategory} handleOpenModal={handleOpenModal} />
+      <CategoryItemDetailsDataTable
+        rowSelected={rowSelected}
+        setRowSelected={setRowSelected}
+        itemsInCategory={itemsInCategory}
+        handleOpenModal={handleOpenModal}
+        handleRemoveAssociation={handleRemoveAssociation}
+      />
       <CategoryItemDetailsGraph itemsInCategory={itemsInCategory} />
       {displayModal && (
-        <SimpleModal title={`Add items to ${selectedCategory?.name}`} handleClose={resetSelection} maxSize="md">
+        <SimpleModal
+          title={`Add items to ${selectedCategory?.name}`}
+          handleClose={resetSelection}
+          showSecondaryButton
+          secondaryButtonAction={addItems}
+          disableSecondaryButton={rowSelected.length <= 0}
+          secondaryButtonIcon={<AddRounded />}
+          maxSize="md"
+        >
           <CategoryItemDetailsAddAsset
             rowSelected={rowSelected}
-            selectedCategory={selectedCategory}
             setRowSelected={setRowSelected}
             itemsInCategory={itemsInCategory}
-            resetSelection={resetSelection}
           />
         </SimpleModal>
       )}

--- a/frontend/src/features/CategoryItemDetails/CategoryItemDetails.jsx
+++ b/frontend/src/features/CategoryItemDetails/CategoryItemDetails.jsx
@@ -14,6 +14,7 @@ import CategoryItemDetailsHeader from './CategoryItemDetailsHeader/CategoryItemD
 import CategoryItemDetailsAddAsset from './CategoryItemDetailsAddAsset/CategoryItemDetailsAddAsset';
 import CategoryItemDetailsDataTable from './CategoryItemDetailsContent/CategoryItemDetailsDataTable';
 import { ConfirmationBoxModal } from '../../common/utils';
+import { enqueueSnackbar } from 'notistack';
 
 export default function CategoryItemDetails() {
   const { id } = useParams();
@@ -46,12 +47,18 @@ export default function CategoryItemDetails() {
 
   const confirmDelete = () => {
     dispatch(categoryItemDetailsActions.removeItemsFromCategory({ id: selectedCategory?.id, rowSelected }));
+    enqueueSnackbar(`Removed association of assets for ${selectedCategory.name}.`, {
+      variant: 'default',
+    });
     resetConfirmationBoxModal();
   };
 
   const addItems = () => {
     const collaborators = selectedCategory.sharable_groups;
     dispatch(categoryItemDetailsActions.addItemsInCategory({ id: selectedCategory?.id, rowSelected, collaborators }));
+    enqueueSnackbar(`Added association of assets for ${selectedCategory.name}.`, {
+      variant: 'success',
+    });
     resetSelection();
   };
 

--- a/frontend/src/features/CategoryItemDetails/CategoryItemDetails.jsx
+++ b/frontend/src/features/CategoryItemDetails/CategoryItemDetails.jsx
@@ -13,6 +13,7 @@ import CategoryItemDetailsGraph from './CategoryItemDetailsContent/CategoryItemD
 import CategoryItemDetailsHeader from './CategoryItemDetailsHeader/CategoryItemDetailsHeader';
 import CategoryItemDetailsAddAsset from './CategoryItemDetailsAddAsset/CategoryItemDetailsAddAsset';
 import CategoryItemDetailsDataTable from './CategoryItemDetailsContent/CategoryItemDetailsDataTable';
+import { ConfirmationBoxModal } from '../../common/utils';
 
 export default function CategoryItemDetails() {
   const { id } = useParams();
@@ -27,15 +28,25 @@ export default function CategoryItemDetails() {
 
   const [rowSelected, setRowSelected] = useState([]);
   const [displayModal, setDisplayModal] = useState(false);
+  const [openConfirmationBoxModal, setOpenConfirmationBoxModal] = useState(false);
 
   const handleOpenModal = () => {
     setDisplayModal(true);
     dispatch(inventoryActions.getAllInventoriesForUser());
   };
 
+  const handleOpenConfirmationBoxModal = () => setOpenConfirmationBoxModal(!openConfirmationBoxModal);
+
   const resetSelection = () => {
     setDisplayModal(false);
     setRowSelected([]);
+  };
+
+  const resetConfirmationBoxModal = () => setOpenConfirmationBoxModal(false);
+
+  const confirmDelete = () => {
+    dispatch(categoryItemDetailsActions.removeItemsFromCategory({ id: selectedCategory?.id, rowSelected }));
+    resetConfirmationBoxModal();
   };
 
   const addItems = () => {
@@ -45,7 +56,7 @@ export default function CategoryItemDetails() {
   };
 
   const handleRemoveAssociation = () => {
-    dispatch(categoryItemDetailsActions.removeItemsFromCategory({ id: selectedCategory?.id, rowSelected }));
+    handleOpenConfirmationBoxModal();
   };
 
   useEffect(() => {
@@ -93,6 +104,13 @@ export default function CategoryItemDetails() {
           />
         </SimpleModal>
       )}
+      <ConfirmationBoxModal
+        openDialog={openConfirmationBoxModal}
+        title="Confirm deletion"
+        handleClose={resetConfirmationBoxModal}
+        maxSize="xs"
+        confirmDelete={confirmDelete}
+      />
     </Stack>
   );
 }

--- a/frontend/src/features/CategoryItemDetails/CategoryItemDetailsAddAsset/CategoryItemDetailsAddAsset.jsx
+++ b/frontend/src/features/CategoryItemDetails/CategoryItemDetailsAddAsset/CategoryItemDetailsAddAsset.jsx
@@ -1,20 +1,12 @@
 import dayjs from 'dayjs';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
-import { Button, Stack } from '@mui/material';
+import { Stack } from '@mui/material';
 
-import { categoryItemDetailsActions } from '../categoryItemDetailsSlice';
 import { VIEW_INVENTORY_LIST_HEADERS } from '../../InventoryList/constants';
 import TableComponent from '../../../common/DataTable/CustomTableComponent/TableComponent';
 
-export default function CategoryItemDetailsAddAsset({
-  selectedCategory,
-  rowSelected,
-  setRowSelected,
-  resetSelection,
-  itemsInCategory,
-}) {
-  const dispatch = useDispatch();
+export default function CategoryItemDetailsAddAsset({ rowSelected, setRowSelected, itemsInCategory }) {
   const { inventories, loading: inventoriesLoading } = useSelector((state) => state.inventory);
 
   const unassignedAssetsForCategories = inventories.filter(
@@ -54,17 +46,8 @@ export default function CategoryItemDetailsAddAsset({
     return row[column] ?? '-';
   };
 
-  const addItems = () => {
-    const collaborators = selectedCategory.sharable_groups;
-    dispatch(categoryItemDetailsActions.addItemsInCategory({ id: selectedCategory?.id, rowSelected, collaborators }));
-    resetSelection();
-  };
-
   return (
     <Stack spacing={1}>
-      <Button variant="outlined" disabled={rowSelected.length <= 0} sx={{ mt: '1rem' }} onClick={addItems}>
-        Add Selected items
-      </Button>
       <TableComponent
         isLoading={inventoriesLoading}
         showActions={false}

--- a/frontend/src/features/CategoryItemDetails/CategoryItemDetailsContent/CategoryItemDetailsDataTable.jsx
+++ b/frontend/src/features/CategoryItemDetails/CategoryItemDetailsContent/CategoryItemDetailsDataTable.jsx
@@ -3,8 +3,8 @@ import { AddRounded, RemoveRounded } from '@mui/icons-material';
 
 import RowHeader from '../../../common/RowHeader';
 import { pluralizeWord } from '../../../common/utils';
-import TableComponent from '../../../common/DataTable/CustomTableComponent/TableComponent';
 import { VIEW_INVENTORY_LIST_HEADERS } from '../../InventoryList/constants';
+import TableComponent from '../../../common/DataTable/CustomTableComponent/TableComponent';
 
 export default function CategoryItemDetailsDataTable({
   rowSelected,

--- a/frontend/src/features/CategoryItemDetails/CategoryItemDetailsContent/CategoryItemDetailsDataTable.jsx
+++ b/frontend/src/features/CategoryItemDetails/CategoryItemDetailsContent/CategoryItemDetailsDataTable.jsx
@@ -1,12 +1,49 @@
 import { Paper } from '@mui/material';
-import { AddRounded } from '@mui/icons-material';
+import { AddRounded, RemoveRounded } from '@mui/icons-material';
 
 import RowHeader from '../../../common/RowHeader';
-import DataTable from '../../../common/DataTable/DataTable';
-import { ITEMS_IN_CATEGORY_HEADER } from '../../Categories/constants';
 import { pluralizeWord } from '../../../common/utils';
+import TableComponent from '../../../common/DataTable/CustomTableComponent/TableComponent';
+import { VIEW_INVENTORY_LIST_HEADERS } from '../../InventoryList/constants';
 
-export default function CategoryItemDetailsDataTable({ itemsInCategory, handleOpenModal }) {
+export default function CategoryItemDetailsDataTable({
+  rowSelected,
+  setRowSelected,
+  itemsInCategory,
+  handleOpenModal,
+  handleRemoveAssociation,
+}) {
+  const handleRowSelection = (_, id) => {
+    if (id === 'all') {
+      if (rowSelected.length !== 0) {
+        setRowSelected([]);
+      } else {
+        setRowSelected(itemsInCategory.map((v) => v.id));
+      }
+    } else {
+      const selectedIndex = rowSelected.indexOf(id);
+      let draftSelected = [];
+      if (selectedIndex === -1) {
+        draftSelected = draftSelected.concat(rowSelected, id);
+      } else if (selectedIndex === 0) {
+        draftSelected = draftSelected.concat(rowSelected.slice(1));
+      } else if (selectedIndex === rowSelected.length - 1) {
+        draftSelected = draftSelected.concat(rowSelected.slice(0, -1));
+      } else if (selectedIndex > 0) {
+        draftSelected = draftSelected.concat(rowSelected.slice(0, selectedIndex), rowSelected.slice(selectedIndex + 1));
+      }
+      setRowSelected(draftSelected);
+    }
+  };
+
+  const rowFormatter = (row, columnName, columnData) => {
+    if (columnData.modifier) {
+      return columnData.modifier(row[columnName] || '-');
+    } else {
+      return row[columnName] || '-';
+    }
+  };
+
   return (
     <Paper elevation={1} sx={{ padding: '1rem' }}>
       <RowHeader
@@ -15,12 +52,19 @@ export default function CategoryItemDetailsDataTable({ itemsInCategory, handleOp
         primaryButtonTextLabel="Add"
         primaryStartIcon={<AddRounded />}
         handleClickPrimaryButton={handleOpenModal}
+        secondaryButtonTextLabel="Remove"
+        secondaryStartIcon={<RemoveRounded color="error" />}
+        handleClickSecondaryButton={handleRemoveAssociation}
+        secondaryButtonDisabled={rowSelected.length <= 0}
       />
-      <DataTable
-        rows={itemsInCategory}
-        columns={ITEMS_IN_CATEGORY_HEADER}
-        isEmpty={itemsInCategory === null}
-        subtitle={'Associate items into category to begin.'}
+      <TableComponent
+        showActions={false}
+        data={itemsInCategory}
+        columns={Object.values(VIEW_INVENTORY_LIST_HEADERS).filter((v) => v.displayConcise)}
+        rowFormatter={rowFormatter}
+        rowSelected={rowSelected}
+        handleRowSelection={handleRowSelection}
+        emptyComponentSubtext="Create inventory items to associate them."
       />
     </Paper>
   );

--- a/frontend/src/features/CategoryItemDetails/categoryItemDetailsSaga.js
+++ b/frontend/src/features/CategoryItemDetails/categoryItemDetailsSaga.js
@@ -52,6 +52,21 @@ export function* fetchAddItemsInCategory(action) {
   }
 }
 
+export function* removeItemsFromCategory(action) {
+  try {
+    const userID = localStorage.getItem('userID');
+    const { id, rowSelected } = action.payload;
+    yield call(instance.post, `${BASEURL}/category/remove/items`, {
+      id,
+      userID,
+      assetIDs: rowSelected,
+    });
+    yield put(categoryItemDetailsActions.removeItemsFromCategorySuccess(rowSelected));
+  } catch (e) {
+    yield put(categoryItemDetailsActions.removeItemsFromCategoryFailure(e));
+  }
+}
+
 export function* uploadImage(action) {
   try {
     const { id, selectedImage } = action.payload;
@@ -91,6 +106,10 @@ export function* watchFetchAddItemsInCategory() {
   yield takeLatest(`categoryItemDetails/addItemsInCategory`, fetchAddItemsInCategory);
 }
 
+export function* watchRemoveItemsFromCategory() {
+  yield takeLatest(`categoryItemDetails/removeItemsFromCategory`, removeItemsFromCategory);
+}
+
 export function* watchUploadImage() {
   yield takeLatest(`categoryItemDetails/uploadImage`, uploadImage);
 }
@@ -103,6 +122,7 @@ export default [
   watchGetCategory,
   watchGetItemsForCategory,
   watchFetchAddItemsInCategory,
+  watchRemoveItemsFromCategory,
   watchUploadImage,
   watchGetSelectedImage,
 ];

--- a/frontend/src/features/CategoryItemDetails/categoryItemDetailsSlice.js
+++ b/frontend/src/features/CategoryItemDetails/categoryItemDetailsSlice.js
@@ -56,6 +56,21 @@ const categoryItemDetailsSlice = createSlice({
       state.error = '';
       state.itemsInCategory = [];
     },
+    removeItemsFromCategory: (state) => {
+      state.loading = true;
+      state.error = '';
+    },
+    removeItemsFromCategorySuccess: (state, action) => {
+      const removedItems = action.payload;
+      const filteredItemsFromCategoryList = state.itemsInCategory.filter((v) => !removedItems.includes(v.id));
+      state.loading = false;
+      state.error = '';
+      state.itemsInCategory = [...filteredItemsFromCategoryList];
+    },
+    removeItemsFromCategoryFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+    },
     uploadImage: (state) => {
       state.error = '';
     },

--- a/frontend/src/features/InventoryList/constants.jsx
+++ b/frontend/src/features/InventoryList/constants.jsx
@@ -1,8 +1,9 @@
 import dayjs from 'dayjs';
+
 import relativeTime from 'dayjs/plugin/relativeTime';
-import QrCodeGen from './ViewItemDetails/QrCodeGen';
 import { CheckRounded, CloseRounded } from '@mui/icons-material';
 
+import QrCodeGen from './ViewItemDetails/QrCodeGen';
 dayjs.extend(relativeTime);
 
 /**
@@ -92,7 +93,7 @@ export const VIEW_INVENTORY_LIST_HEADERS = {
     colName: 'price',
     label: 'Cost',
     displayConcise: true,
-    modifier: (value) => `${value || '-'}`,
+    modifier: (value) => `${+value || '-'}`,
   },
   barcode: {
     id: 5,
@@ -111,7 +112,7 @@ export const VIEW_INVENTORY_LIST_HEADERS = {
     colName: 'quantity',
     label: 'Qty',
     displayConcise: true,
-    modifier: (value) => `${value || '-'}`,
+    modifier: (value) => `${+value || '-'}`,
   },
   location: {
     id: 8,
@@ -177,7 +178,7 @@ export const VIEW_INVENTORY_LIST_HEADERS = {
   },
   updator_name: {
     id: 17,
-    colName: 'updater_name',
+    colName: 'updator',
     label: 'Updated By',
     displayConcise: true,
     modifier: (value) => `${value || '-'}`,

--- a/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetails.jsx
+++ b/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetails.jsx
@@ -14,6 +14,7 @@ import MaintenancePlanItemDetailsHeader from './MaintenancePlanItemDetailsHeader
 import MaintenancePlanItemDetailsContent from './MaintenancePlanItemDetailsContent/MaintenancePlanItemDetailsContent';
 import MaintenancePlanItemDetailsAddAsset from './MaintenancePlanItemDetailsAddAsset/MaintenancePlanItemDetailsAddAsset';
 import { ConfirmationBoxModal } from '../../common/utils';
+import { enqueueSnackbar } from 'notistack';
 
 export default function MaintenancePlanItemDetails() {
   const { id } = useParams();
@@ -43,6 +44,9 @@ export default function MaintenancePlanItemDetails() {
     dispatch(
       maintenancePlanItemActions.removeItemsFromMaintenancePlan({ id: selectedMaintenancePlan?.id, rowSelected })
     );
+    enqueueSnackbar(`Removed association of assets for ${selectedMaintenancePlan.name}.`, {
+      variant: 'default',
+    });
     resetConfirmationBoxModal();
   };
 
@@ -51,6 +55,9 @@ export default function MaintenancePlanItemDetails() {
     dispatch(
       maintenancePlanItemActions.addItemsInPlan({ id: selectedMaintenancePlan?.id, rowSelected, collaborators })
     );
+    enqueueSnackbar(`Added association of assets for ${selectedMaintenancePlan.name}.`, {
+      variant: 'success',
+    });
     resetSelection();
   };
 

--- a/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetails.jsx
+++ b/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetails.jsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Skeleton, Stack } from '@mui/material';
+import { AddRounded } from '@mui/icons-material';
 
 import SimpleModal from '../../common/SimpleModal';
 import { inventoryActions } from '../InventoryList/inventorySlice';
@@ -32,6 +33,20 @@ export default function MaintenancePlanItemDetails() {
     dispatch(inventoryActions.getAllInventoriesForUser());
   };
 
+  const addItems = () => {
+    const collaborators = selectedMaintenancePlan.sharable_groups;
+    dispatch(
+      maintenancePlanItemActions.addItemsInPlan({ id: selectedMaintenancePlan?.id, rowSelected, collaborators })
+    );
+    resetSelection();
+  };
+
+  const handleRemoveAssociation = () => {
+    dispatch(
+      maintenancePlanItemActions.removeItemsFromMaintenancePlan({ id: selectedMaintenancePlan?.id, rowSelected })
+    );
+  };
+
   const resetSelection = () => {
     setDisplayModal(false);
     setRowSelected([]);
@@ -57,15 +72,28 @@ export default function MaintenancePlanItemDetails() {
         item={selectedMaintenancePlan}
         image={selectedMaintenancePlanImage}
       />
-      <MaintenancePlanItemDetailsContent totalItems={itemsInMaintenancePlan} handleOpenModal={handleOpenModal} />
+      <MaintenancePlanItemDetailsContent
+        rowSelected={rowSelected}
+        setRowSelected={setRowSelected}
+        itemsInMaintenancePlan={itemsInMaintenancePlan}
+        handleOpenModal={handleOpenModal}
+        handleRemoveAssociation={handleRemoveAssociation}
+      />
       <MaintenancePlanItemDetailsGraph totalItems={itemsInMaintenancePlan} />
       {displayModal && (
-        <SimpleModal title={`Add items to ${selectedMaintenancePlan?.name}`} handleClose={resetSelection} maxSize="md">
+        <SimpleModal
+          title={`Add items to ${selectedMaintenancePlan?.name}`}
+          handleClose={resetSelection}
+          maxSize="md"
+          showSecondaryButton
+          secondaryButtonAction={addItems}
+          secondaryButtonIcon={<AddRounded />}
+          disableSecondaryButton={rowSelected.length <= 0}
+        >
           <MaintenancePlanItemDetailsAddAsset
             rowSelected={rowSelected}
             setRowSelected={setRowSelected}
             resetSelection={resetSelection}
-            selectedMaintenancePlan={selectedMaintenancePlan}
             itemsInMaintenancePlan={itemsInMaintenancePlan}
           />
         </SimpleModal>

--- a/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetails.jsx
+++ b/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetails.jsx
@@ -13,6 +13,7 @@ import MaintenancePlanItemDetailsGraph from './MaintenancePlanItemDetailsContent
 import MaintenancePlanItemDetailsHeader from './MaintenancePlanItemDetailsHeader/MaintenancePlanItemDetailsHeader';
 import MaintenancePlanItemDetailsContent from './MaintenancePlanItemDetailsContent/MaintenancePlanItemDetailsContent';
 import MaintenancePlanItemDetailsAddAsset from './MaintenancePlanItemDetailsAddAsset/MaintenancePlanItemDetailsAddAsset';
+import { ConfirmationBoxModal } from '../../common/utils';
 
 export default function MaintenancePlanItemDetails() {
   const { id } = useParams();
@@ -25,12 +26,24 @@ export default function MaintenancePlanItemDetails() {
     loading = false,
   } = useSelector((state) => state.maintenancePlanItem);
 
-  const [displayModal, setDisplayModal] = useState(false);
   const [rowSelected, setRowSelected] = useState([]);
+  const [displayModal, setDisplayModal] = useState(false);
+  const [openConfirmationBoxModal, setOpenConfirmationBoxModal] = useState(false);
 
   const handleOpenModal = () => {
     setDisplayModal(true);
     dispatch(inventoryActions.getAllInventoriesForUser());
+  };
+
+  const handleOpenConfirmationBoxModal = () => setOpenConfirmationBoxModal(!openConfirmationBoxModal);
+
+  const resetConfirmationBoxModal = () => setOpenConfirmationBoxModal(false);
+
+  const confirmDelete = () => {
+    dispatch(
+      maintenancePlanItemActions.removeItemsFromMaintenancePlan({ id: selectedMaintenancePlan?.id, rowSelected })
+    );
+    resetConfirmationBoxModal();
   };
 
   const addItems = () => {
@@ -42,9 +55,7 @@ export default function MaintenancePlanItemDetails() {
   };
 
   const handleRemoveAssociation = () => {
-    dispatch(
-      maintenancePlanItemActions.removeItemsFromMaintenancePlan({ id: selectedMaintenancePlan?.id, rowSelected })
-    );
+    handleOpenConfirmationBoxModal();
   };
 
   const resetSelection = () => {
@@ -98,6 +109,13 @@ export default function MaintenancePlanItemDetails() {
           />
         </SimpleModal>
       )}
+      <ConfirmationBoxModal
+        openDialog={openConfirmationBoxModal}
+        title="Confirm deletion"
+        handleClose={resetConfirmationBoxModal}
+        maxSize="xs"
+        confirmDelete={confirmDelete}
+      />
     </Stack>
   );
 }

--- a/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetailsAddAsset/MaintenancePlanItemDetailsAddAsset.jsx
+++ b/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetailsAddAsset/MaintenancePlanItemDetailsAddAsset.jsx
@@ -1,20 +1,12 @@
 import dayjs from 'dayjs';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
-import { Button, Stack } from '@mui/material';
+import { Stack } from '@mui/material';
 
-import { maintenancePlanItemActions } from '../maintenancePlanItemSlice';
 import { VIEW_INVENTORY_LIST_HEADERS } from '../../InventoryList/constants';
 import TableComponent from '../../../common/DataTable/CustomTableComponent/TableComponent';
 
-export default function MaintenancePlanItemDetailsAddAsset({
-  rowSelected,
-  setRowSelected,
-  resetSelection,
-  selectedMaintenancePlan,
-  itemsInMaintenancePlan,
-}) {
-  const dispatch = useDispatch();
+export default function MaintenancePlanItemDetailsAddAsset({ rowSelected, setRowSelected, itemsInMaintenancePlan }) {
   const { inventories, loading: inventoriesLoading } = useSelector((state) => state.inventory);
 
   const handleRowSelection = (_, id) => {
@@ -46,19 +38,8 @@ export default function MaintenancePlanItemDetailsAddAsset({
     return row[column] ?? '-';
   };
 
-  const addItems = () => {
-    const collaborators = selectedMaintenancePlan.sharable_groups;
-    dispatch(
-      maintenancePlanItemActions.addItemsInPlan({ id: selectedMaintenancePlan?.id, rowSelected, collaborators })
-    );
-    resetSelection();
-  };
-
   return (
     <Stack spacing={1}>
-      <Button variant="outlined" disabled={rowSelected.length <= 0} sx={{ mt: '1rem' }} onClick={addItems}>
-        Add Selected items
-      </Button>
       <TableComponent
         showActions={false}
         isLoading={inventoriesLoading}

--- a/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetailsContent/MaintenancePlanItemDetailsContent.jsx
+++ b/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetailsContent/MaintenancePlanItemDetailsContent.jsx
@@ -1,26 +1,70 @@
 import { Paper } from '@mui/material';
-import { AddRounded } from '@mui/icons-material';
+import { AddRounded, RemoveRounded } from '@mui/icons-material';
 
 import RowHeader from '../../../common/RowHeader';
 import { pluralizeWord } from '../../../common/utils';
-import DataTable from '../../../common/DataTable/DataTable';
-import { ITEMS_IN_MAINTENANCE_PLAN_HEADER } from '../../MaintenancePlanList/constants';
+import { VIEW_INVENTORY_LIST_HEADERS } from '../../InventoryList/constants';
+import TableComponent from '../../../common/DataTable/CustomTableComponent/TableComponent';
 
-export default function MaintenancePlanItemDetailsContent({ totalItems, handleOpenModal }) {
+export default function MaintenancePlanItemDetailsContent({
+  rowSelected,
+  setRowSelected,
+  itemsInMaintenancePlan,
+  handleOpenModal,
+  handleRemoveAssociation,
+}) {
+  const handleRowSelection = (_, id) => {
+    if (id === 'all') {
+      if (rowSelected.length !== 0) {
+        setRowSelected([]);
+      } else {
+        setRowSelected(itemsInMaintenancePlan.map((v) => v.id));
+      }
+    } else {
+      const selectedIndex = rowSelected.indexOf(id);
+      let draftSelected = [];
+      if (selectedIndex === -1) {
+        draftSelected = draftSelected.concat(rowSelected, id);
+      } else if (selectedIndex === 0) {
+        draftSelected = draftSelected.concat(rowSelected.slice(1));
+      } else if (selectedIndex === rowSelected.length - 1) {
+        draftSelected = draftSelected.concat(rowSelected.slice(0, -1));
+      } else if (selectedIndex > 0) {
+        draftSelected = draftSelected.concat(rowSelected.slice(0, selectedIndex), rowSelected.slice(selectedIndex + 1));
+      }
+      setRowSelected(draftSelected);
+    }
+  };
+
+  const rowFormatter = (row, columnName, columnData) => {
+    if (columnData.modifier) {
+      return columnData.modifier(row[columnName] || '-');
+    } else {
+      return row[columnName] || '-';
+    }
+  };
+
   return (
     <Paper elevation={1} sx={{ padding: '1rem' }}>
       <RowHeader
         title="Items"
-        caption={`Total ${pluralizeWord('item', totalItems?.length || 0)}`}
-        primaryButtonTextLabel="Add Items"
+        caption={`Total ${pluralizeWord('item', itemsInMaintenancePlan?.length || 0)}`}
+        primaryButtonTextLabel="Add"
         primaryStartIcon={<AddRounded />}
         handleClickPrimaryButton={handleOpenModal}
+        secondaryButtonTextLabel="Remove"
+        secondaryStartIcon={<RemoveRounded color="error" />}
+        handleClickSecondaryButton={handleRemoveAssociation}
+        secondaryButtonDisabled={rowSelected.length <= 0}
       />
-      <DataTable
-        rows={totalItems}
-        isEmpty={totalItems === null}
-        columns={ITEMS_IN_MAINTENANCE_PLAN_HEADER}
-        subtitle={'Associate items into maintenance plan to begin.'}
+      <TableComponent
+        showActions={false}
+        data={itemsInMaintenancePlan}
+        columns={Object.values(VIEW_INVENTORY_LIST_HEADERS).filter((v) => v.displayConcise)}
+        rowFormatter={rowFormatter}
+        rowSelected={rowSelected}
+        handleRowSelection={handleRowSelection}
+        emptyComponentSubtext="Create inventory items to associate them."
       />
     </Paper>
   );

--- a/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSaga.js
+++ b/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSaga.js
@@ -52,6 +52,21 @@ export function* fetchAddItemsInPlan(action) {
   }
 }
 
+export function* removeItemsFromMaintenancePlan(action) {
+  try {
+    const userID = localStorage.getItem('userID');
+    const { id, rowSelected } = action.payload;
+    yield call(instance.post, `${BASEURL}/plan/remove/items`, {
+      id,
+      userID,
+      assetIDs: rowSelected,
+    });
+    yield put(maintenancePlanItemActions.removeItemsFromMaintenancePlanSuccess(rowSelected));
+  } catch (e) {
+    yield put(maintenancePlanItemActions.removeItemsFromMaintenancePlanFailure(e));
+  }
+}
+
 export function* uploadImage(action) {
   try {
     const { id, selectedImage } = action.payload;
@@ -91,6 +106,10 @@ export function* watchFetchAddItemsInPlan() {
   yield takeLatest(`maintenancePlanItem/addItemsInPlan`, fetchAddItemsInPlan);
 }
 
+export function* watchRemoveItemsFromMaintenancePlan() {
+  yield takeLatest(`maintenancePlanItem/removeItemsFromMaintenancePlan`, removeItemsFromMaintenancePlan);
+}
+
 export function* watchUploadImage() {
   yield takeLatest(`maintenancePlanItem/uploadImage`, uploadImage);
 }
@@ -103,6 +122,7 @@ export default [
   watchFetchAddItemsInPlan,
   watchGetItemsInMaintenancePlan,
   watchGetSelectedMaintenancePlan,
+  watchRemoveItemsFromMaintenancePlan,
   watchGetSelectedImage,
   watchUploadImage,
 ];

--- a/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSlice.js
+++ b/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSlice.js
@@ -54,6 +54,21 @@ const maintenancePlanItemSlice = createSlice({
       state.loading = false;
       state.error = '';
     },
+    removeItemsFromMaintenancePlan: (state) => {
+      state.loading = true;
+      state.error = '';
+    },
+    removeItemsFromMaintenancePlanSuccess: (state, action) => {
+      const removedItems = action.payload;
+      const filteredItemsFromCategoryList = state.itemsInMaintenancePlan.filter((v) => !removedItems.includes(v.id));
+      state.loading = false;
+      state.error = '';
+      state.itemsInMaintenancePlan = [...filteredItemsFromCategoryList];
+    },
+    removeItemsFromMaintenancePlanFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+    },
     uploadImage: (state) => {
       state.error = '';
     },

--- a/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSlice.js
+++ b/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSlice.js
@@ -60,10 +60,10 @@ const maintenancePlanItemSlice = createSlice({
     },
     removeItemsFromMaintenancePlanSuccess: (state, action) => {
       const removedItems = action.payload;
-      const filteredItemsFromCategoryList = state.itemsInMaintenancePlan.filter((v) => !removedItems.includes(v.id));
+      const filteredItems = state.itemsInMaintenancePlan.filter((v) => !removedItems.includes(v.id));
       state.loading = false;
       state.error = '';
-      state.itemsInMaintenancePlan = [...filteredItemsFromCategoryList];
+      state.itemsInMaintenancePlan = [...filteredItems];
     },
     removeItemsFromMaintenancePlanFailure: (state) => {
       state.loading = false;

--- a/frontend/src/features/MaintenancePlanList/constants.jsx
+++ b/frontend/src/features/MaintenancePlanList/constants.jsx
@@ -1,4 +1,4 @@
-import dayjs from "dayjs";
+import dayjs from 'dayjs';
 
 export const ITEMS_IN_MAINTENANCE_PLAN_HEADER = [
   { field: 'name', headerName: 'Name', flex: 1 },
@@ -6,7 +6,7 @@ export const ITEMS_IN_MAINTENANCE_PLAN_HEADER = [
   { field: 'price', headerName: 'Price', flex: 1 },
   { field: 'quantity', headerName: 'Quantity', flex: 1 },
   { field: 'location', headerName: 'Storage Location', flex: 1 },
-  { field: 'updater_name', headerName: 'Last updated by', flex: 1 },
+  { field: 'updator', headerName: 'Last updated by', flex: 1 },
 ];
 
 export const ITEM_TYPE_MAPPER = {
@@ -34,7 +34,6 @@ export const ITEM_TYPE_MAPPER = {
     display: 'Quaterly',
     value: 'quaterly',
     since: dayjs().add(3, 'months').toISOString(),
-
   },
   semiannually: {
     display: 'Semi-annually',


### PR DESCRIPTION
[273 - Updated item association](https://github.com/earmuff-jam/pulse/pull/275/commits/aa19f4e046df14b1e6d8baaee4e856e811a449db)

- Added the ability to remove item association between
categories, maintenance plans and assets. Added backend support
for this effort for both categories and maintenance plans and added
ui integration to support this feature.

- Removed use case of Datatable and used tableComponent instead because
of our various customization needs, that needed to be supported by Datatable.
For now, using our own tableComponent provided better support than using
the custom solution of muiv5 data table.

- Updated tech debt and cleanup on components such as removing console.log
across the newly created components. Also updated inventories api handler
to provide a consistent updator name instead of updater_name vs updator that
we use in categories and maintenance items.

Closes https://github.com/earmuff-jam/pulse/issues/271