### PR TITLE
311 Added support for maintenance alerts

### DIFF
--- a/.github/workflows/mashed-main.yml
+++ b/.github/workflows/mashed-main.yml
@@ -3,25 +3,33 @@ name: CI
 on: [push]
 
 env:
-  GO111MODULE: "on" # Enable Go modules
+  GO111MODULE: "on"
   DOCKER_DRIVER: overlay
 
 jobs:
   build-backend:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_USER: runner
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: community
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Build Custom Postgres Image
+        run: |
+          docker build -t custom-postgres:latest -f ./server/Dockerfile .
+
+      - name: Run Custom Postgres Container
+        run: |
+          docker run -d -p 5432:5432 --name ci-postgres -e POSTGRES_USER=runner -e POSTGRES_PASSWORD=password -e POSTGRES_DB=community custom-postgres:latest
+          echo "Waiting for Postgres to be ready..."
+          for i in {1..20}; do
+            if docker exec ci-postgres pg_isready -U runner -d community; then
+              echo "Postgres is ready!"
+              break
+            fi
+            echo "Postgres not ready yet, sleeping for 5 seconds..."
+            sleep 5
+          done
 
       - name: Install Golang migrate dependency
         run: |
@@ -53,6 +61,12 @@ jobs:
           echo "Attempting to build go code."
           go version
           cd apilayer/handler && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out
+
+      - name: Stop Postgres Container
+        if: always()
+        run: |
+          docker stop ci-postgres
+          docker rm ci-postgres
 
   build-frontend:
     runs-on: ubuntu-latest

--- a/apilayer/handler/ProfileHandler_test.go
+++ b/apilayer/handler/ProfileHandler_test.go
@@ -89,6 +89,18 @@ func Test_GetProfileStats_InvalidDBUser(t *testing.T) {
 	assert.Equal(t, "400 Bad Request", res.Status)
 }
 
+func Test_GetNotifications_InvalidDBUser(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/profile/0902c692-b8e2-4824-a870-e52f4a0cccf8/notifications", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "0802c692-b8e2-4824-a870-e52f4a0cccf8"})
+	w := httptest.NewRecorder()
+	db.PreloadAllTestVariables()
+	GetNotifications(w, req, config.CEO_USER)
+	res := w.Result()
+
+	assert.Equal(t, 400, res.StatusCode)
+	assert.Equal(t, "400 Bad Request", res.Status)
+}
+
 func Test_GetProfileApi(t *testing.T) {
 
 	// profile are automatically derieved from the auth table. due to this, we attempt to create a new user

--- a/apilayer/main.go
+++ b/apilayer/main.go
@@ -97,6 +97,8 @@ func main() {
 	router.Handle("/api/v1/profile/list", CustomRequestHandler(handler.GetAllUserProfiles)).Methods(http.MethodGet)
 	router.Handle("/api/v1/profile/{id}", CustomRequestHandler(handler.GetProfile)).Methods(http.MethodGet)
 	router.Handle("/api/v1/profile/{id}/stats", CustomRequestHandler(handler.GetProfileStats)).Methods(http.MethodGet)
+	router.Handle("/api/v1/profile/{id}/notifications", CustomRequestHandler(handler.GetNotifications)).Methods(http.MethodGet)
+	router.Handle("/api/v1/profile/{id}/notifications", CustomRequestHandler(handler.UpdateSelectedMaintenanceNotification)).Methods(http.MethodPut)
 	router.Handle("/api/v1/profile/{id}/recent-activities", CustomRequestHandler(handler.GetRecentActivities)).Methods(http.MethodGet)
 	router.Handle("/api/v1/profile/{id}", CustomRequestHandler(handler.UpdateProfile)).Methods(http.MethodPut)
 	router.Handle("/api/v1/profile/{id}/username", CustomRequestHandler(handler.GetUsername)).Methods(http.MethodGet)

--- a/apilayer/model/Profile.go
+++ b/apilayer/model/Profile.go
@@ -50,6 +50,33 @@ type ProfileStats struct {
 	TotalAssets           int `json:"totalAssets"`
 }
 
+// MaintenanceAlertNotifications ...
+// swagger:model MaintenanceAlertNotifications
+//
+// MaintenanceAlertNotifications object that returns the notifications alert for the maintenance plans that are within 7 days of being due
+type MaintenanceAlertNotifications struct {
+	ID             string    `json:"maintenance_plan_id"`
+	Name           string    `json:"name"`
+	Type           string    `json:"type"`
+	PlanDue        time.Time `json:"plan_due"`
+	IsRead         bool      `json:"is_read"`
+	UpdatedAt      time.Time `json:"updated_at,omitempty"`
+	UpdatedBy      string    `json:"updated_by,omitempty"`
+	Updator        string    `json:"updator,omitempty"`
+	SharableGroups []string  `json:"sharable_groups"`
+}
+
+// MaintenanceAlertNotificationRequest ...
+// swagger:model MaintenanceAlertNotificationRequest
+//
+// MaintenanceAlertNotificationRequest object that is used to update the db based on user selection.
+type MaintenanceAlertNotificationRequest struct {
+	ID        string    `json:"maintenance_plan_id"`
+	IsRead    bool      `json:"is_read"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedBy string    `json:"updated_by,omitempty"`
+}
+
 // Location ...
 // swagger:model Location
 //

--- a/frontend/src/features/Layout/AppToolbar/AppToolbar.jsx
+++ b/frontend/src/features/Layout/AppToolbar/AppToolbar.jsx
@@ -2,12 +2,12 @@ import { AppBar, Toolbar } from '@mui/material';
 import AppToolbarTitle from '@features/Layout/AppToolbar/AppToolbarTitle';
 import AppToolbarActionButtons from '@features/Layout/AppToolbar/AppToolbarActionButtons';
 
-export default function AppToolbar({ profileDetails, handleDrawerOpen, smScreenSizeAndHigher }) {
+export default function AppToolbar({ profileDetails, handleDrawerOpen }) {
   return (
     <AppBar elevation={0}>
       <Toolbar sx={{ backgroundColor: 'accentColor.default' }}>
         <AppToolbarTitle onClick={handleDrawerOpen} />
-        <AppToolbarActionButtons profileDetails={profileDetails} smScreenSizeAndHigher={smScreenSizeAndHigher} />
+        <AppToolbarActionButtons profileDetails={profileDetails} />
       </Toolbar>
     </AppBar>
   );

--- a/frontend/src/features/Layout/AppToolbar/AppToolbarActionButtons.jsx
+++ b/frontend/src/features/Layout/AppToolbar/AppToolbarActionButtons.jsx
@@ -1,12 +1,26 @@
-import { useDispatch } from 'react-redux';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { IconButton, Stack, Tooltip } from '@mui/material';
+import { Badge, IconButton, Stack, Tooltip } from '@mui/material';
+
+import { DarkModeRounded, LightModeOutlined, LogoutRounded, CircleNotifications } from '@mui/icons-material';
+
 import { authActions } from '@features/LandingPage/authSlice';
 import { profileActions } from '@features/Profile/profileSlice';
-import { DarkModeRounded, LightModeOutlined, LogoutRounded } from '@mui/icons-material';
+import AppToolbarPopoverContent from '@features/Layout/AppToolbar/AppToolbarPopoverContent';
 
-export default function AppToolbarActionButtons({ profileDetails, smScreenSizeAndHigher }) {
+export default function AppToolbarActionButtons({ profileDetails }) {
+  const { maintenanceNotifications = [], loading } = useSelector((state) => state.profile);
+
   const dispatch = useDispatch();
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleClick = (event) => setAnchorEl(event.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+
+  const toggleReadOption = (id, selection) => {
+    dispatch(profileActions.toggleMaintenanceNotificationReadOption({ maintenance_plan_id: id, is_read: !selection }));
+  };
 
   const handleAppearance = () => {
     const draftData = { ...profileDetails, appearance: !profileDetails.appearance || false };
@@ -19,29 +33,35 @@ export default function AppToolbarActionButtons({ profileDetails, smScreenSizeAn
     window.location.href = '/';
   };
 
+  useEffect(() => {
+    dispatch(profileActions.getMaintenanceNotifications());
+  }, []);
+
   return (
     <Stack direction="row" spacing="0.1rem">
-      {!smScreenSizeAndHigher ? (
-        <>
-          <IconButton size="small" onClick={handleAppearance}>
-            {profileDetails?.appearance ? <LightModeOutlined fontSize="small" /> : <DarkModeRounded fontSize="small" />}
-          </IconButton>
-          <IconButton size="small" onClick={handleLogout}>
-            <LogoutRounded fontSize="small" />
-          </IconButton>
-        </>
-      ) : (
-        <>
-          <IconButton size="small" onClick={() => handleAppearance()}>
-            {profileDetails?.appearance ? <LightModeOutlined fontSize="small" /> : <DarkModeRounded fontSize="small" />}
-          </IconButton>
-          <Tooltip title="log out">
-            <IconButton size="small" onClick={handleLogout}>
-              <LogoutRounded fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        </>
-      )}
+      <IconButton size="small" onClick={handleClick}>
+        <Badge
+          badgeContent={maintenanceNotifications?.filter((notification) => !notification?.is_read).length || 0}
+          color="secondary"
+        >
+          <CircleNotifications />
+        </Badge>
+      </IconButton>
+      <IconButton size="small" onClick={handleAppearance}>
+        {profileDetails?.appearance ? <LightModeOutlined fontSize="small" /> : <DarkModeRounded fontSize="small" />}
+      </IconButton>
+      <Tooltip title="log out">
+        <IconButton size="small" onClick={handleLogout}>
+          <LogoutRounded fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <AppToolbarPopoverContent
+        loading={loading}
+        anchorEl={anchorEl}
+        handleClose={handleClose}
+        toggleReadOption={toggleReadOption}
+        options={maintenanceNotifications}
+      />
     </Stack>
   );
 }

--- a/frontend/src/features/Layout/AppToolbar/AppToolbarPopoverContent.jsx
+++ b/frontend/src/features/Layout/AppToolbar/AppToolbarPopoverContent.jsx
@@ -1,0 +1,53 @@
+import dayjs from 'dayjs';
+
+import { CircleRounded, DoneRounded } from '@mui/icons-material';
+import { Menu, MenuItem, Skeleton, Stack, Typography } from '@mui/material';
+import { EmptyComponent } from '@common/utils';
+
+export default function AppToolbarPopoverContent({ loading, anchorEl, handleClose, toggleReadOption, options = [] }) {
+  const open = Boolean(anchorEl);
+
+  if (loading) return <Skeleton height="100%" />;
+
+  return (
+    <Menu
+      id="long-menu"
+      MenuListProps={{
+        'aria-labelledby': 'long-button',
+      }}
+      anchorEl={anchorEl}
+      open={open}
+      onClose={handleClose}
+    >
+      <Typography variant="h6" fontStyle="bold" sx={{ padding: '0rem 1rem' }}>
+        Due Maintenance Plans
+      </Typography>
+      {(!options || options?.length <= 0) && (
+        <EmptyComponent padding="1rem 1rem" subtitle="No new maintenance plans due." />
+      )}
+
+      {options?.map((option) => (
+        <MenuItem
+          key={option.maintenance_plan_id}
+          disabled={option.is_read}
+          onClick={() => {
+            toggleReadOption(option.maintenance_plan_id, option.is_read);
+            handleClose();
+          }}
+        >
+          <Stack direction="row" alignItems="center" spacing={1}>
+            {option.is_read ? (
+              <DoneRounded sx={{ width: '0.7rem', height: '0.7rem', color: 'success.main' }} />
+            ) : (
+              <CircleRounded sx={{ width: '0.7rem', height: '0.7rem', color: 'error.main' }} />
+            )}
+
+            <Typography variant="caption">
+              {option.name} is due {dayjs(option.plan_due).fromNow()}
+            </Typography>
+          </Stack>
+        </MenuItem>
+      ))}
+    </Menu>
+  );
+}

--- a/frontend/src/features/Layout/Layout.jsx
+++ b/frontend/src/features/Layout/Layout.jsx
@@ -52,11 +52,7 @@ const Layout = () => {
           </Box>
         }
       >
-        <AppToolbar
-          profileDetails={profileDetails}
-          handleDrawerOpen={handleDrawerOpen}
-          smScreenSizeAndHigher={smScreenSizeAndHigher}
-        />
+        <AppToolbar profileDetails={profileDetails} handleDrawerOpen={handleDrawerOpen} />
         <Stack sx={{ marginTop: '5rem', marginBottom: '1rem' }}>
           <MenuActionBar
             openDrawer={openDrawer}

--- a/frontend/src/features/Profile/profileSaga.js
+++ b/frontend/src/features/Profile/profileSaga.js
@@ -35,6 +35,30 @@ export function* fetchProfileStats() {
   }
 }
 
+export function* fetchMaintenanceNotifications() {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    const response = yield call(instance.get, `${BASEURL}/profile/${USER_ID}/notifications`);
+    yield put(profileActions.getMaintenanceNotificationsSuccess(response.data));
+  } catch (e) {
+    yield put(profileActions.getMaintenanceNotificationsFailure(e));
+  }
+}
+
+export function* fetchToggleMaintenanceNotificationReadOption(action) {
+  try {
+    const USER_ID = localStorage.getItem('userID');
+    yield call(instance.put, `${BASEURL}/profile/${USER_ID}/notifications`, {
+      ...action.payload,
+      updated_by: USER_ID,
+    });
+
+    yield put(profileActions.toggleMaintenanceNotificationReadOptionSuccess(action.payload));
+  } catch (e) {
+    yield put(profileActions.toggleMaintenanceNotificationReadOptionFailure(e));
+  }
+}
+
 export function* fetchRecentActivities() {
   try {
     const USER_ID = localStorage.getItem('userID');
@@ -155,6 +179,14 @@ export function* watchFetchProfileStats() {
   yield takeLatest(`profile/getProfileStats`, fetchProfileStats);
 }
 
+export function* watchFetchMaintenanceNotifications() {
+  yield takeLatest(`profile/getMaintenanceNotifications`, fetchMaintenanceNotifications);
+}
+
+export function* watchFetchToggleMaintenanceNotificationReadOption() {
+  yield takeLatest(`profile/toggleMaintenanceNotificationReadOption`, fetchToggleMaintenanceNotificationReadOption);
+}
+
 export function* watchFetchRecentActivities() {
   yield takeLatest(`profile/getRecentActivities`, fetchRecentActivities);
 }
@@ -199,4 +231,6 @@ export default [
   watchFetchExistingUserDetails,
   watchUpdateExistingUserDetails,
   watchFetchUpdateProfileImage,
+  watchFetchMaintenanceNotifications,
+  watchFetchToggleMaintenanceNotificationReadOption,
 ];

--- a/frontend/src/features/Profile/profileSlice.js
+++ b/frontend/src/features/Profile/profileSlice.js
@@ -7,6 +7,7 @@ const initialState = {
   error: '',
   profiles: [],
   profileStats: {},
+  maintenanceNotifications: [],
   profileDetails: {},
   avatar: '',
   recentActivities: [],
@@ -44,6 +45,43 @@ const profileSlice = createSlice({
       state.loading = false;
       state.error = '';
       state.profileStats = {};
+    },
+    getMaintenanceNotifications: (state) => {
+      state.error = '';
+      state.maintenanceNotifications = [];
+    },
+    getMaintenanceNotificationsSuccess: (state, action) => {
+      state.maintenanceNotifications = action.payload;
+      state.loading = false;
+      state.error = '';
+    },
+    getMaintenanceNotificationsFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+      state.maintenanceNotifications = [];
+    },
+    toggleMaintenanceNotificationReadOption: (state) => {
+      state.error = '';
+    },
+    toggleMaintenanceNotificationReadOptionSuccess: (state, action) => {
+      const { maintenance_plan_id, is_read, updated_at, updated_by } = action.payload;
+
+      const index = state.maintenanceNotifications.findIndex(
+        (item) => item.maintenance_plan_id === maintenance_plan_id
+      );
+
+      if (index !== -1) {
+        state.maintenanceNotifications[index] = {
+          ...state.maintenanceNotifications[index],
+          is_read,
+          updated_at,
+          updated_by,
+        };
+      }
+      state.error = '';
+    },
+    toggleMaintenanceNotificationReadOptionFailure: (state) => {
+      state.error = '';
     },
     getRecentActivities: (state) => {
       state.loading = true;

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,10 @@
-FROM postgres:latest
+FROM postgres:15.4
+RUN apt-get update && apt-get install -y curl
+
+
+RUN apt-get -y install postgresql-15-cron
+RUN echo "shared_preload_libraries='pg_cron'" >> /usr/share/postgresql/postgresql.conf.sample
+RUN echo "cron.database_name='community'" >> /usr/share/postgresql/postgresql.conf.sample
 
 # Expose port 5432
 EXPOSE 5432

--- a/server/migrations/0028_create_maintenance_alert_table.up.sql
+++ b/server/migrations/0028_create_maintenance_alert_table.up.sql
@@ -1,0 +1,29 @@
+
+-- File: 0028_create_maintenance_alert_table.up.sql
+-- Description: Creates maintenance alert table to alert the users of all the items that are past due in maintenance
+-- Note:- updated_by is not forced to use the UUID because the system can make this change automatically --
+
+SET search_path TO community, public;
+
+CREATE TABLE IF NOT EXISTS community.maintenance_alert
+(
+    id                      UUID                                                                                                         PRIMARY KEY        NOT NULL    DEFAULT gen_random_uuid(),
+    maintenance_plan_id     UUID                        UNIQUE REFERENCES maintenance_plan (id) ON UPDATE CASCADE ON DELETE CASCADE,
+    name                    VARCHAR(100),
+    type                    TEXT                                                                                                                            NOT NULL,
+    plan_due                TIMESTAMP WITH TIME ZONE                                                                                                        NOT NULL    DEFAULT NOW(),
+    is_read                 BOOLEAN                                                                                                                                     DEFAULT false,
+    updated_by              TEXT,
+    updated_at              TIMESTAMP WITH TIME ZONE                                                                                                        NOT NULL    DEFAULT NOW(),
+    sharable_groups         UUID[]
+);
+
+COMMENT ON TABLE maintenance_alert IS 'table to support list of maintenance plans that are due. Due date is derieved from the maintenance plan table.';
+
+ALTER TABLE community.maintenance_alert ADD CONSTRAINT unique_maintenance_plan_id_type UNIQUE (maintenance_plan_id, type);
+
+ALTER TABLE community.maintenance_alert OWNER TO community_admin;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON community.maintenance_alert TO community_public;
+GRANT SELECT, INSERT, UPDATE, DELETE ON community.maintenance_alert TO community_test;
+GRANT ALL PRIVILEGES ON TABLE community.maintenance_alert TO community_admin;

--- a/server/migrations/0029_create_maintenance_alert_threshold_fn.up.sql
+++ b/server/migrations/0029_create_maintenance_alert_threshold_fn.up.sql
@@ -1,0 +1,45 @@
+
+-- File: 0029_create_maintenance_alert_threshold_fn.up
+-- Description: Function used to populate the maintenance alert. If the plan_due date is within the time
+-- frame of 7 days, then we want to populate the maintenance alert table.
+
+-- Note:- updated_by is not forced to use the UUID because the system can make this change automatically --
+
+
+SET search_path TO community, public;
+
+CREATE EXTENSION pg_cron;
+
+
+
+--
+-- Utility function that is used to populate maintenance alerts if they pass the threshold of 7 days. --
+-- All maintenance plans that cross 7 days mark are displayed in the table --
+--
+
+CREATE OR REPLACE FUNCTION community.populate_maintenance_alerts()
+RETURNS void AS
+$$
+BEGIN
+    INSERT INTO community.maintenance_alert (maintenance_plan_id, name, type, plan_due, is_read, updated_by, updated_at, sharable_groups)
+    SELECT 
+        mp.id, 
+        mp.name, 
+        mp.plan_type, 
+        mp.plan_due, 
+        false, 
+        'system',
+        NOW(),
+        mp.sharable_groups
+    FROM community.maintenance_plan mp
+    WHERE mp.plan_due::DATE BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '7 days' 
+     ON CONFLICT (maintenance_plan_id) DO UPDATE 
+    SET 
+        plan_due = EXCLUDED.plan_due, 
+        updated_at = NOW();
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- Cron Scheduler to run the function populate_maintenance_alerts every day --
+SELECT cron.schedule('0 0 * * *', $$CALL community.populate_maintenance_alerts();$$);

--- a/server/migrations/0030_create_maintenance_alert_threshold_trigger.up.sql
+++ b/server/migrations/0030_create_maintenance_alert_threshold_trigger.up.sql
@@ -1,0 +1,53 @@
+
+-- File: 0030_create_maintenance_alert_threshold_trigger.up.sql
+-- Description: Creates trigger to populate the maintenance alert if the audience member changes
+-- the plan due date to be within the 7 days period.
+
+-- Note:- updated_by is not forced to use the UUID because the system can make this change automatically --
+
+
+SET search_path TO community, public;
+
+--
+-- utility fn created to update maintenance alert table --
+-- 
+DROP FUNCTION IF EXISTS community.update_maintenance_alert_function_on_plan_due_change_fn() CASCADE;
+CREATE FUNCTION community.update_maintenance_alert_function_on_plan_due_change_fn()
+    RETURNS trigger AS
+$$
+BEGIN
+INSERT INTO community.maintenance_alert (maintenance_plan_id, name, type, plan_due, is_read, updated_by, updated_at, sharable_groups)
+    SELECT 
+        mp.id, 
+        mp.name, 
+        mp.plan_type,
+        mp.plan_due, 
+        false, 
+        NEW.updated_by::TEXT,
+        NOW(),
+        mp.sharable_groups 
+    FROM community.maintenance_plan mp
+    WHERE mp.plan_due::DATE BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '7 days'
+     ON CONFLICT (maintenance_plan_id) DO UPDATE 
+    SET 
+        is_read = CASE 
+            WHEN community.maintenance_alert.plan_due IS DISTINCT FROM EXCLUDED.plan_due 
+            THEN false
+            ELSE community.maintenance_alert.is_read
+        END,
+        plan_due = EXCLUDED.plan_due, 
+        updated_at = NOW();
+
+RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 
+-- trigger used to populate the maintenance alert table --
+--
+DROP TRIGGER IF EXISTS update_maintenance_alert_function_on_plan_due_change_trigger ON community.maintenance_plan;
+CREATE TRIGGER update_maintenance_alert_function_on_plan_due_change_trigger
+    AFTER INSERT OR UPDATE
+        ON community.maintenance_plan
+    FOR EACH ROW
+EXECUTE FUNCTION community.update_maintenance_alert_function_on_plan_due_change_fn();


### PR DESCRIPTION
- Created api to support maintenance alerts

Created struct to handle the notifications and created seperate struct to handle the update process of the notification. Since we do not need a lot of the struct values, we just created a new struct in leu of reusing the older struct.

Created apilayer code to support displaying a list of maintenance alerts that are not read for the user. Added sql code to retrieve the alerts that are made by the collaborators of the alerts table. This collaborators are populated from the maintenance plan table. So in theory, if the maintenance plan has more collaborators the alert is shared across all of them.

Any one can mark the alert as complete. The userID of the person who marked the alert complete is displayed in the updated by section of the table and is inclusive of the timestamp of the performed action. If a new alert is created by the system then the table shall read the label - system.

- Created sql functions to support maintenance alerts table

Added sql table to house the alerts for each maintenance plan. There should be only one alert per maintenance plan. If the user changes the maintenance plan, then the alert is re-populated if necessary ( if the conditions for the alert ) match.

Added pg cron extension and updated the docker container to house the extension. By doing this, we are able to use the pg_cron extension and fire up the cron scheduler to update the table at a selected time every day to build new alerts.

Added trigger function to update the alerts table after change is occured on the maintenance plan table. This is required because if a user changes a maintenance plan to be within the 7 days period of due date, then the trigger function will update the alert table.

- Updated Redux and Saga to handle the new alerts api

Added fetch functions to retrieve the notifications and update functions to update the notifications alerts from the redux action. The redux instead does a opmistic update to the code, since the db only returns 200 ok if the put is successful.

- Created new UI components to support the notifications popover content

Added new toolbar icons and popover content to display the notifications. Clicking on any of the selected toolbar notification will attempt to mark the notification as is_read or complete. This in turn will remove the notification next time the page is viewed.

Closes #311