### PR TITLE
313 Update minor bug fixes

### DIFF
--- a/frontend/src/common/ItemCard/DetailsCard.jsx
+++ b/frontend/src/common/ItemCard/DetailsCard.jsx
@@ -56,7 +56,7 @@ export default function DetailsCard({ selectedItem, selectedImage, categoryMode 
       }
     });
     if (categoryMode) {
-      dispatch(categoryItemDetailsActions.updateCategory(draftSelectionDetails));
+      dispatch(categoryItemDetailsActions.updateCollaborators(draftSelectionDetails));
       enqueueSnackbar('Updated collaborators for selected category.', {
         variant: 'success',
       });
@@ -64,7 +64,7 @@ export default function DetailsCard({ selectedItem, selectedImage, categoryMode 
         navigate('/');
       }
     } else {
-      dispatch(maintenancePlanItemActions.updatePlan(draftSelectionDetails));
+      dispatch(maintenancePlanItemActions.updateCollaborators(draftSelectionDetails));
       enqueueSnackbar('Updated collaborators for selected maintenance plan.', {
         variant: 'success',
       });

--- a/frontend/src/features/Assets/inventorySaga.js
+++ b/frontend/src/features/Assets/inventorySaga.js
@@ -132,7 +132,8 @@ export function* uploadImage(action) {
 export function* uploadAndRefreshDataSuccess(action) {
   /**
    * Fixes https://github.com/earmuff-jam/pulse/issues/305.
-   * Refetch the data once the image is updated in the system.
+   * Refetch the data once the image is updated in the system. Re-use the same function for selected asset details.
+   * If the user is viewing selected asset and refreshes the page, the user should see the new image as well.
    */
   try {
     const { id, selectedImage } = action.payload;
@@ -162,6 +163,7 @@ export function* uploadAndRefreshDataSuccess(action) {
     }
 
     yield put(inventoryActions.getAllInventoriesForUserSuccess(response.data || {}));
+    yield put(inventoryActions.getSelectedImage({ id: id }));
     yield put(inventoryActions.uploadImageSuccess(response.data));
   } catch (e) {
     yield put(inventoryActions.uploadImageFailure(e));

--- a/frontend/src/features/CategoryItemDetails/CategoryItemDetails.jsx
+++ b/frontend/src/features/CategoryItemDetails/CategoryItemDetails.jsx
@@ -70,7 +70,7 @@ export default function CategoryItemDetails() {
   };
 
   useEffect(() => {
-    if (!loading && !selectedCategoryImage) {
+    if (!loading) {
       dispatch(categoryItemDetailsActions.getSelectedImage({ id }));
     }
   }, [loading]);

--- a/frontend/src/features/CategoryItemDetails/categoryItemDetailsSaga.js
+++ b/frontend/src/features/CategoryItemDetails/categoryItemDetailsSaga.js
@@ -21,6 +21,16 @@ export function* getCategory(action) {
   }
 }
 
+export function* updateCollaborators(action) {
+  try {
+    const { id } = action.payload;
+    const response = yield call(instance.put, `${BASEURL}/category/${id}`, { ...action.payload });
+    yield put(categoryItemDetailsActions.updateCollaboratorsSuccess(response.data));
+  } catch (e) {
+    yield put(categoryItemDetailsActions.updateCollaboratorsFailure(e));
+  }
+}
+
 export function* getItemsForCategory(action) {
   try {
     const catID = action.payload;
@@ -109,6 +119,10 @@ export function* watchGetItemsForCategory() {
   yield takeLatest(`categoryItemDetails/getItemsForCategory`, getItemsForCategory);
 }
 
+export function* watchUpdateCollaborators() {
+  yield takeLatest(`categoryItemDetails/updateCollaborators`, updateCollaborators);
+}
+
 export function* watchFetchAddItemsInCategory() {
   yield takeLatest(`categoryItemDetails/addItemsInCategory`, fetchAddItemsInCategory);
 }
@@ -127,9 +141,10 @@ export function* watchGetSelectedImage() {
 
 export default [
   watchGetCategory,
-  watchGetItemsForCategory,
-  watchFetchAddItemsInCategory,
-  watchRemoveItemsFromCategory,
   watchUploadImage,
   watchGetSelectedImage,
+  watchGetItemsForCategory,
+  watchUpdateCollaborators,
+  watchRemoveItemsFromCategory,
+  watchFetchAddItemsInCategory,
 ];

--- a/frontend/src/features/CategoryItemDetails/categoryItemDetailsSlice.js
+++ b/frontend/src/features/CategoryItemDetails/categoryItemDetailsSlice.js
@@ -27,6 +27,19 @@ const categoryItemDetailsSlice = createSlice({
       state.error = '';
       state.selectedCategory = {};
     },
+    updateCollaborators: (state) => {
+      state.loading = true;
+      state.error = '';
+    },
+    updateCollaboratorsSuccess: (state, action) => {
+      state.selectedCategory = action.payload;
+      state.loading = false;
+      state.error = '';
+    },
+    updateCollaboratorsFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+    },
     getItemsForCategory: (state) => {
       state.loading = true;
       state.error = '';
@@ -77,6 +90,7 @@ const categoryItemDetailsSlice = createSlice({
     },
     uploadImageSuccess: (state) => {
       state.loading = false;
+      state.selectedCategoryImage = '';
       state.error = '';
     },
     uploadImageFailure: (state) => {

--- a/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetails.jsx
+++ b/frontend/src/features/MaintenancePlanItemDetails/MaintenancePlanItemDetails.jsx
@@ -80,10 +80,10 @@ export default function MaintenancePlanItemDetails() {
   };
 
   useEffect(() => {
-    if (!loading && selectedMaintenancePlanImage) {
+    if (!loading) {
       dispatch(maintenancePlanItemActions.getSelectedImage({ id }));
     }
-  }, [loading]);
+  }, [id, loading]);
 
   useEffect(() => {
     if (id) {

--- a/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSaga.js
+++ b/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSaga.js
@@ -21,6 +21,16 @@ export function* getSelectedMaintenancePlan(action) {
   }
 }
 
+export function* updateCollaborators(action) {
+  try {
+    const { id } = action.payload;
+    const response = yield call(instance.put, `${BASEURL}/plan/${id}`, { ...action.payload });
+    yield put(maintenancePlanItemActions.updateCollaboratorsSuccess(response.data));
+  } catch (e) {
+    yield put(maintenancePlanItemActions.updateCollaboratorsFailure(e));
+  }
+}
+
 export function* getItemsInMaintenancePlan(action) {
   try {
     const mID = action.payload;
@@ -109,6 +119,10 @@ export function* watchGetItemsInMaintenancePlan() {
   yield takeLatest(`maintenancePlanItem/getItemsInMaintenancePlan`, getItemsInMaintenancePlan);
 }
 
+export function* watchUpdateCollaborators() {
+  yield takeLatest(`maintenancePlanItem/updateCollaborators`, updateCollaborators);
+}
+
 export function* watchFetchAddItemsInPlan() {
   yield takeLatest(`maintenancePlanItem/addItemsInPlan`, fetchAddItemsInPlan);
 }
@@ -131,5 +145,6 @@ export default [
   watchGetSelectedMaintenancePlan,
   watchRemoveItemsFromMaintenancePlan,
   watchGetSelectedImage,
+  watchUpdateCollaborators,
   watchUploadImage,
 ];

--- a/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSlice.js
+++ b/frontend/src/features/MaintenancePlanItemDetails/maintenancePlanItemSlice.js
@@ -27,6 +27,19 @@ const maintenancePlanItemSlice = createSlice({
       state.error = '';
       state.selectedMaintenancePlan = {};
     },
+    updateCollaborators: (state) => {
+      state.loading = true;
+      state.error = '';
+    },
+    updateCollaboratorsSuccess: (state, action) => {
+      state.selectedMaintenancePlan = action.payload;
+      state.loading = false;
+      state.error = '';
+    },
+    updateCollaboratorsFailure: (state) => {
+      state.loading = false;
+      state.error = '';
+    },
     getItemsInMaintenancePlan: (state) => {
       state.loading = true;
       state.error = '';
@@ -75,6 +88,7 @@ const maintenancePlanItemSlice = createSlice({
     },
     uploadImageSuccess: (state) => {
       state.loading = false;
+      state.selectedMaintenancePlanImage = '';
       state.error = '';
     },
     uploadImageFailure: (state) => {

--- a/frontend/src/features/SelectedAsset/SelectedAsset.jsx
+++ b/frontend/src/features/SelectedAsset/SelectedAsset.jsx
@@ -113,16 +113,21 @@ export default function SelectedAsset() {
   };
 
   const handleUpload = (id, imgFormData) => {
-    dispatch(inventoryActions.uploadImage({ id: id, selectedImage: imgFormData }));
+    dispatch(inventoryActions.uploadAndRefreshData({ id: id, selectedImage: imgFormData }));
     setEditImgMode(false);
   };
 
   useEffect(() => {
     if (id.length > 0) {
       dispatch(inventoryActions.getInvByID(id));
-      dispatch(inventoryActions.getSelectedImage({ id }));
     }
   }, [id]);
+
+  useEffect(() => {
+    if (!loading && !selectedImage) {
+      dispatch(inventoryActions.getSelectedImage({ id }));
+    }
+  }, [loading]);
 
   useEffect(() => {
     if (!loading || !storageLocationsLoading) {
@@ -146,8 +151,8 @@ export default function SelectedAsset() {
       selectedAsset.updated_by.value = inventory.updated_by || '';
       selectedAsset.updated_at.value = inventory.updated_at || '';
       selectedAsset.sharable_groups.value = inventory.sharable_groups || [];
-      selectedAsset.creator_name = inventory.creator_name;
-      selectedAsset.updator_name = inventory.updater_name;
+      selectedAsset.creator_name = inventory?.creator_name || '';
+      selectedAsset.updator_name = inventory?.updater_name || '';
 
       if (inventory?.return_datetime) {
         setReturnDateTime(dayjs(inventory.return_datetime));


### PR DESCRIPTION
Fixed an issue with selected asset with image.

Uploading an image in the selected asset page would not display the image on the fly instead we would have to refresh the page. Fixed the issue by reusing the redux fn uploadAndRefreshDataSuccess so that we can update the selected image from the system on the fly.

Fixed an issue with collaborators not updating for categories and plans.

Collaborators for categories and / or maintenance plans were not being updated since they were not attached properly to the redux action of category item after the split between categories and category item. Hindsight 20/20 maybe we should have just left those two alone since they were related but nevertheless the issue is resolved. Simple fix was to just add the proper dispatch actions and on the slice, we just reset the value of the image if new image was uploaded so that would force the dispatch action to call the new image.

We found some discripancies with the way categories and maintenance plans are updated, since the latter one uses image in its payload. we probably need to investigate that just to make sure everything is correctly functioning and working as intended.

Closes #313

Screenshots / Videos

